### PR TITLE
Remove duplicate avatar icon from sidenav

### DIFF
--- a/apps/frontend/src/components/layout/Sidebar.tsx
+++ b/apps/frontend/src/components/layout/Sidebar.tsx
@@ -78,23 +78,6 @@ const Sidebar: React.FC<SidebarProps> = ({ className = '' }) => {
         </button>
       </div>
 
-      {user && !isCollapsed && (
-        <div className="px-4 py-3 mb-4 border-b border-gray-200">
-          <div className="flex items-center">
-            <Avatar
-              src={user.avatar}
-              alt={user.name}
-              fallback={user.name}
-              size="md"
-            />
-            <div className="ml-3">
-              <p className="text-sm font-medium text-gray-900">{user.name}</p>
-              <p className="text-xs text-gray-500">{user.email}</p>
-            </div>
-          </div>
-        </div>
-      )}
-
       <nav className="flex-1 px-2 space-y-1 overflow-y-auto">
         <SidebarItem
           to="/"


### PR DESCRIPTION
I removed the duplicate user avatar and login information from the left sidebar.

Specifically, in `apps/frontend/src/components/layout/Sidebar.tsx`, I removed:
*   The `div` block containing the `Avatar` component.
*   The associated user name and email display.
*   The surrounding styling and border that created a distinct section for the user's profile information.

This change was made because the user avatar and login details were already present in the upper right `Navbar` component, making the sidebar's inclusion redundant. Now, the sidebar is cleaner and less cluttered, with the user avatar and login information appearing only in the upper right, where it also provides a dropdown menu with additional user details.